### PR TITLE
Fixed annotations initialization bug

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -85,9 +85,6 @@ func (c *Controller) applyService(settings *models.ServiceSettings) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("oauth2-proxy-github-%s-%s", settings.GitHub.Organization, settings.AppName),
 			Namespace: "oauth2-proxy",
-			Annotations: map[string]string{
-				"kubernetes.io/ingress.class": "nginx",
-			},
 		},
 		Spec: apiv1.ServiceSpec{
 			Type: apiv1.ServiceTypeNodePort,
@@ -139,6 +136,9 @@ func (c *Controller) applyIngress(settings *models.ServiceSettings) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth2-proxy",
 			Namespace: "oauth2-proxy",
+			Annotations: map[string]string{
+				"kubernetes.io/ingress.class": "nginx",
+			},
 		},
 		Spec: extensionsv1beta1.IngressSpec{
 			Rules: []extensionsv1beta1.IngressRule{


### PR DESCRIPTION
## WHY
When `INGRESS_CLASS` is set, oauth2-proxy-manager fails to execute `applyIngress` in controller.go.

The error log is shown below. `panic: "assignment to entry in nil map" (assignment to entry in nil map)` occured in controller.go#L166.

https://github.com/Laica-Lunasys/oauth2-proxy-manager/blob/be3031a1c6c955106b1e9d97df7727664b8a6628/service/controller.go#L166

```console
$ kubectl logs po oauth2-proxy-manager-xxx -f
.
.
.
time="2019/08/19 10:42:50" level=info msg="[oauth2_proxy] Updated Deployment! "oauth2-proxy-github-wantedly-dev-docs""
E0819 10:42:50.742318       1 runtime.go:69] Observed a panic: "assignment to entry in nil map" (assignment to entry in nil map)
goroutine 19 [running]:
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x11d75a0, 0x14b59c0)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65 +0x7b
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:47 +0x82
panic(0x11d75a0, 0x14b59c0)
        /usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/Laica-Lunasys/oauth2-proxy-manager/service.(*Controller).applyIngress(0xc000134e70, 0xc0001384e0)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/service/controller.go:166 +0xc1a
github.com/Laica-Lunasys/oauth2-proxy-manager/service.(*Controller).Create(0xc000134e70, 0xc0001384e0)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/service/controller.go:75 +0x11c
github.com/Laica-Lunasys/oauth2-proxy-manager/service.(*Observer).Run.func1(0x1309460, 0xc000456b40)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/service/observer.go:48 +0x1ae
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(...)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache/controller.go:195
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache.newInformer.func1(0x11ea020, 0xc000439660, 0x1, 0xc000439660)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache/controller.go:367 +0x1b6
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache.(*DeltaFIFO).Pop(0xc000134f20, 0xc0002f9e60, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache/delta_fifo.go:436 +0x209
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache.(*controller).processLoop(0xc00030f300)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache/controller.go:150 +0x40
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0000defb0)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x54
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000569fb0, 0x3b9aca00, 0x0, 0xc000269201, 0xc0000d85a0)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/wait.Until(...)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache.(*controller).Run(0xc00030f300, 0xc0000d85a0)
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/vendor/k8s.io/client-go/tools/cache/controller.go:124 +0x2a8
created by github.com/Laica-Lunasys/oauth2-proxy-manager/service.(*Observer).Run
        /go/src/github.com/Laica-Lunasys/oauth2-proxy-manager/service/observer.go:84 +0x333
```

Ingress's Annotation is not initialized in current code. Therefore, this error occurred.

## WHAT
I fixed this bug.

- Added the initialization of annotations to ingress.
- Removed unecessary initialization of annotations from service.