### PR TITLE
Support `set-xauthrequest` feature of oauth2_proxy

### DIFF
--- a/models/oauth2-proxy.go
+++ b/models/oauth2-proxy.go
@@ -2,10 +2,11 @@ package models
 
 // ServiceSettings - Settings from individual services annotations.
 type ServiceSettings struct {
-	AppName    string
-	AuthURL    string
-	AuthSignIn string
-	GitHub     GitHubProvider
+	AppName         string
+	AuthURL         string
+	AuthSignIn      string
+	SetXAuthRequest string
+	GitHub          GitHubProvider
 }
 
 // GitHubProvider - GitHub Provicer

--- a/service/controller.go
+++ b/service/controller.go
@@ -347,6 +347,10 @@ func (c *Controller) applyDeployment(settings *models.ServiceSettings) {
 										},
 									},
 								},
+								apiv1.EnvVar{
+									Name:  "OAUTH2_PROXY_SET_XAUTHREQUEST",
+									Value: settings.SetXAuthRequest,
+								},
 							},
 							Ports: []apiv1.ContainerPort{
 								{

--- a/service/observer.go
+++ b/service/observer.go
@@ -116,18 +116,25 @@ func parseAnnotations(meta metav1.ObjectMeta) (*models.ServiceSettings, error) {
 		return nil, errors.New("github-teams not found. skip.")
 	}
 
+	setXAuthRequest, ok := meta.Annotations["oauth2-proxy-manager.k8s.io/set-xauthrequest"]
+	if !ok {
+		setXAuthRequest = ""
+	}
+
 	logrus.WithFields(logrus.Fields{
-		"ingress.class": meta.Annotations["kubernetes.io/ingress.class"],
-		"auth-url":      meta.Annotations["nginx.ingress.kubernetes.io/auth-url"],
-		"auth-signin":   meta.Annotations["nginx.ingress.kubernetes.io/auth-signin"],
-		"github-org":    meta.Annotations["oauth2-proxy-manager.k8s.io/github-org"],
-		"github-teams":  meta.Annotations["oauth2-proxy-manager.k8s.io/github-teams"],
+		"ingress.class":    meta.Annotations["kubernetes.io/ingress.class"],
+		"auth-url":         meta.Annotations["nginx.ingress.kubernetes.io/auth-url"],
+		"auth-signin":      meta.Annotations["nginx.ingress.kubernetes.io/auth-signin"],
+		"github-org":       meta.Annotations["oauth2-proxy-manager.k8s.io/github-org"],
+		"github-teams":     meta.Annotations["oauth2-proxy-manager.k8s.io/github-teams"],
+		"set-xauthrequest": setXAuthRequest,
 	}).Debug("[ParseAnnotations]")
 
 	settings := &models.ServiceSettings{
-		AppName:    meta.Annotations["oauth2-proxy-manager.k8s.io/app-name"],
-		AuthURL:    meta.Annotations["nginx.ingress.kubernetes.io/auth-url"],
-		AuthSignIn: meta.Annotations["nginx.ingress.kubernetes.io/auth-signin"],
+		AppName:         meta.Annotations["oauth2-proxy-manager.k8s.io/app-name"],
+		AuthURL:         meta.Annotations["nginx.ingress.kubernetes.io/auth-url"],
+		AuthSignIn:      meta.Annotations["nginx.ingress.kubernetes.io/auth-signin"],
+		SetXAuthRequest: setXAuthRequest,
 		GitHub: models.GitHubProvider{
 			Organization: meta.Annotations["oauth2-proxy-manager.k8s.io/github-org"],
 			Teams:        strings.Split(meta.Annotations["oauth2-proxy-manager.k8s.io/github-teams"], ","),


### PR DESCRIPTION
This PR enables `set-xauthrequest` feature of oauth2_proxy if `oauth2-proxy-manager.k8s.io/set-xauthrequest` annotation is set.

> Option | Type | Description | Default
> -- | -- | -- | --
> -set-xauthrequest | bool | set X-Auth-Request-User and X-Auth-Request-Email response headers (useful in Nginx auth_request mode) | false
>
> https://pusher.github.io/oauth2_proxy/configuration

(This feature can be enabled by `OAUTH2_PROXY_SET_XAUTHREQUEST`. My implementation uses this environment variable. [ref](https://github.com/pusher/oauth2_proxy/blob/9f920b0fc151ffdc057540c7dfdc87c612a2f8e7/options.go#L81))